### PR TITLE
Add extreme n_query function and add script to time simulations

### DIFF
--- a/asreview2-opt/main.py
+++ b/asreview2-opt/main.py
@@ -43,6 +43,25 @@ def n_query(results, n_records):
         return 1
 
 
+def n_query_extreme(results, n_records):
+    if n_records >= 10000:
+        if len(results) >= 10000:
+            return 10**5  # finish the run
+        if len(results) >= 1000:
+            return 1000
+        elif len(results) >= 100:
+            return 25
+        else:
+            return 1
+    else:
+        if len(results) >= 1000:
+            return 100
+        elif len(results) >= 100:
+            return 5
+        else:
+            return 1
+
+
 def sort_studies(studies, dataset_sizes):
     studies_sorter = sorted(dataset_sizes.items(), key=lambda x: x[1], reverse=True)
 

--- a/asreview2-opt/runtime_estimate.py
+++ b/asreview2-opt/runtime_estimate.py
@@ -1,0 +1,108 @@
+import multiprocessing as mp
+import pickle
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import synergy_dataset as sd
+
+import asreview
+from asreview.metrics import loss
+from asreview.models.balance import Balanced
+from asreview.models.feature_extraction import Tfidf
+from asreview.models.query import MaxQuery
+
+from asreview.models.classifiers import (
+    RandomForestClassifier,
+)
+
+# Study variables
+PICKLE_FOLDER_PATH = Path("synergy-dataset", "pickles")
+N_STUDIES = 260
+CLASSIFIER_TYPE = "nb"  # Options: "nb", "log", "svm", "rf"
+STUDY_NAME = "ASReview2 " + datetime.now().strftime("%Y-%m-%d at %H.%M.%S")
+PARALLELIZE_OBJECTIVE = True
+
+# Optuna variables
+OPTUNA_N_TRIALS = 500
+OPTUNA_TIMEOUT = None  # in seconds
+OPTUNA_N_JOBS = 1 if PARALLELIZE_OBJECTIVE else mp.cpu_count() - 2
+
+# Early stopping condition variables
+MIN_TRIALS = 100
+N_HISTORY = 5
+STOPPING_THRESHOLD = 0.001
+
+
+def _sort_studies(studies, dataset_sizes, ascending=True):
+    studies_sorter = sorted(dataset_sizes.items(), key=lambda x: x[1], reverse=True)
+
+    return studies.sort_values(
+        "dataset_id",
+        key=lambda x: x.map({val[0]: i for i, val in enumerate(studies_sorter)}),
+        ascending=ascending,
+    )
+
+
+def n_query_extreme(results, n_records):
+    if n_records >= 10000:
+        if len(results) >= 10000:
+            return 10**5  # finish the run
+        if len(results) >= 1000:
+            return 1000
+        elif len(results) >= 100:
+            return 25
+        else:
+            return 1
+    else:
+        if len(results) >= 1000:
+            return 100
+        elif len(results) >= 100:
+            return 5
+        else:
+            return 1
+
+
+# Function to process each row
+def run_sysrev_sim(row):
+    with open(PICKLE_FOLDER_PATH / f"{row['dataset_id']}.pkl", "rb") as f:
+        fm, labels = pickle.load(f)
+
+    priors = row["prior_inclusions"] + row["prior_exclusions"]
+
+    blc = Balanced(ratio=1.5)
+
+    simulate = asreview.Simulate(
+        fm=fm,
+        labels=labels,
+        classifier=RandomForestClassifier(),
+        balance_strategy=blc,
+        query_strategy=MaxQuery(),
+        feature_extraction=Tfidf(),
+        n_query=lambda x: n_query_extreme(x, dataset_sizes[row["dataset_id"]]),
+    )
+
+    simulate.label(priors, prior=True)
+    simulate.review()
+
+    padded_results = list(simulate._results["label"]) + [0] * (
+        len(simulate.labels) - len(simulate._results["label"])
+    )
+    return loss(padded_results)
+
+
+if __name__ == "__main__":
+    dataset_sizes = {
+        dataset.name: dataset.metadata["data"]["n_records"]
+        for dataset in sd.iter_datasets()
+    }
+
+    with open("asreview2-opt/synergy_studies_1000.jsonl", "r") as f:
+        studies = pd.read_json(f, lines=True).groupby("dataset_id").head(1)
+
+    studies = _sort_studies(
+        studies=studies, dataset_sizes=dataset_sizes, ascending=True
+    )
+
+    for index, study in studies.iterrows():
+        run_sysrev_sim(study)


### PR DESCRIPTION
```

 Walker_2018
Relevant records found: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 762/762 [06:42<00:00,  1.89it/s]
Records labeled       : 110000it [06:42, 273.58it/s]                                                                                                    

Loss: 0.18
Loss: <function loss at 0x1282589a0>



 Brouwer_2019
Relevant records found: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 62/62 [02:17<00:00,  2.26s/it]
Records labeled       : 110000it [02:17, 798.46it/s]                                                                                                    

Loss: 0.06
Loss: <function loss at 0x1282589a0>



 van_Dis_2020
Relevant records found: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 72/72 [05:16<00:00,  4.46s/it]
Records labeled       :  99%|█████████████████████████████████████████████████████████████████████████████████████▊ | 9000/9128 [05:16<00:04, 28.40it/s]

Loss: 0.19
Loss: <function loss at 0x1282589a0>



 Hall_2012
Relevant records found:  95%|█████████████████████████████████████████████████████████████████████████████████████▋    | 99/104 [00:57<00:18,  3.64s/it^[[1;2Bs labeled       :   8%|██████▉                                                                                 | 695/8793 [00:58<15:49,  8.53it/s^Relevant records found: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 104/104 [02:28<00:00,  1.45s/it]
Records labeled       :  43%|█████████████████████████████████████▌                                                 | 3800/8793 [02:28<03:15, 25.50it/s]

Loss: 0.03
Loss: <function loss at 0x1282589a0>


```